### PR TITLE
now replacing spaces with %20 in url for find_player_id

### DIFF
--- a/R/find_player_id.R
+++ b/R/find_player_id.R
@@ -10,6 +10,7 @@
 find_player_id <- function(searchstring) {
   url <- paste0("http://stats.espncricinfo.com/ci/engine/stats/analysis.html?search=",
                 searchstring,";template=analysis")
+  url <- gsub(" ", "%20", url)
   raw <- try(xml2::read_html(url), silent = TRUE)
   if ("try-error" %in% class(raw))
     stop("This shouldn't happen")


### PR DESCRIPTION
find_player_id returns an error if the search string has a space because it generates a bad url. replacing spaces with "%20" resolves the problem