### PR TITLE
extend find_player_id() to take a character vector as argument

### DIFF
--- a/R/find_player_id.R
+++ b/R/find_player_id.R
@@ -1,6 +1,6 @@
 #' Find a player id from cricinfo.com
 #'
-#' @param searchstring Part of a player name to search for.
+#' @param searchstring Part of a player name(s) to search for. Can be a character vector.
 #' @return A table of matching players, their ids, and teams they played for.
 #' @examples
 #' (perry <- find_player_id("Perry"))
@@ -11,35 +11,46 @@ find_player_id <- function(searchstring) {
   url <- paste0("http://stats.espncricinfo.com/ci/engine/stats/analysis.html?search=",
                 searchstring,";template=analysis")
   url <- gsub(" ", "%20", url)
-  raw <- try(xml2::read_html(url), silent = TRUE)
-  if ("try-error" %in% class(raw))
+  raw <- lapply(url, function(x) {
+    print(x)
+    try(xml2::read_html(x), silent = TRUE)
+    })
+  if ("try-error" %in% lapply(raw, class))
     stop("This shouldn't happen")
   # Extract table of names
-  tab <- rvest::html_table(raw)[[1]]
+  tab <- lapply(raw, function(x) rvest::html_table(x)[[1]])
   # Make into a table
-  tab <- tibble::as_tibble(tab)
-  # Check if player exists
-  if(unlist(tab[1,1])=="No matching players found")
-    stop("No matching players found")
+  tab <- lapply(tab, function(x) {
+    x <- tibble::as_tibble(x)
+    x <- x[x$X1 != "",]
+  })
+  
+  for(i in seq_along(searchstring)) {
+    x <- tab[[i]]
+    # Check if any players returned
+    if(x[1,1] == "No matching players found")
+      warning(paste("No matching players found for search:", searchstring[i]))
+    #Check if return exceeds 100
+    if(grepl("Search restricted", x[nrow(x), 1])) {
+      warning(paste0("Only the first 100 results returned for search: '", searchstring[i],
+                    "'. Try a more specific search"))
+      tab[[i]] <- x[1:100,]
+    }
+  }
+  
+  tab <- dplyr::bind_rows(tab)
+  
   # Name columns
   colnames(tab) <- c("Name","Country","Played")
-  # Remove empty rows
-  tab <- tab[tab$Name != "",]
-  checkrestrict <- grep("Search restricted", utils::tail(tab,1)[[1]])
-  if(length(checkrestrict) == 0L)
-    checkrestrict <- FALSE
-  if(checkrestrict)
-  {
-    warning("Only 100 results returned. Please try a more specific search.")
-    tab <- utils::head(tab,100)
-  }
   # Now to find the ids
-  ids <- rvest::html_nodes(raw, 'a')
-  ids <- as.character(ids[grep("/ci/engine/player/", ids)])
-  ids <- gsub("([a-zA-Z= \\\"/<>]*)","", ids)
-  ids <- unlist(lapply(strsplit(ids,".", fixed=TRUE), function(x){x[1]}))
-  tab$ID <- as.integer(unique(ids))
-  return(tab[,c("ID","Name","Country","Played")])
+  ids <- lapply(raw, rvest::html_nodes, css = 'a')
+  ids <- lapply(ids, function(x) as.character(x[grep("/ci/engine/player/", x)]))
+  ids <- lapply(ids, function(x) gsub("([a-zA-Z= \\\"/<>]*)","", x))
+  ids <- lapply(ids, function(x) unlist(lapply(strsplit(x,".", fixed=TRUE), function(x){x[1]})))
+  # Insert NA for those without matches
+  ids <- lapply(ids, unique)
+  ids <- lapply(ids, function(x) if(is.null(x)) NA else as.numeric(x))
+  tab$ID <- unlist(ids)
+  tab$searchstring <- rep(searchstring, times = unlist(lapply(ids, length)))
+  return(tab[,c("ID","Name","searchstring", "Country","Played")])
 }
-
-

--- a/R/find_player_id.R
+++ b/R/find_player_id.R
@@ -11,10 +11,7 @@ find_player_id <- function(searchstring) {
   url <- paste0("http://stats.espncricinfo.com/ci/engine/stats/analysis.html?search=",
                 searchstring,";template=analysis")
   url <- gsub(" ", "%20", url)
-  raw <- lapply(url, function(x) {
-    print(x)
-    try(xml2::read_html(x), silent = TRUE)
-    })
+  raw <- lapply(url, function(x) try(xml2::read_html(x), silent = TRUE))
   if ("try-error" %in% lapply(raw, class))
     stop("This shouldn't happen")
   # Extract table of names


### PR DESCRIPTION
Feel free to reject or change this PR, but I wanted to pass a vector of names into `find_player_id` (output from `fetch_cricinfo()`), so I made these changes. 

The returned tibble has a new column with searchstring to link the returned values with the input string.

Loving this package!