### PR TITLE
Add size parameter to url

### DIFF
--- a/R/fetch_cricket_data.R
+++ b/R/fetch_cricket_data.R
@@ -53,7 +53,7 @@ fetch_cricket_data <- function(matchtype = c("test", "odi", "t20"),
         ";template=results;type=",
         activity,
         view_text,
-        ";size=200;wrappertype=print"
+        ";wrappertype=print"
       )
 
     # Get raw page data from page using xml2::read_html() with url string.

--- a/R/fetch_cricket_data.R
+++ b/R/fetch_cricket_data.R
@@ -53,7 +53,7 @@ fetch_cricket_data <- function(matchtype = c("test", "odi", "t20"),
         ";template=results;type=",
         activity,
         view_text,
-        ";wrappertype=print"
+        ";size=200;wrappertype=print"
       )
 
     # Get raw page data from page using xml2::read_html() with url string.


### PR DESCRIPTION
Queries can have a size parameter of 50, 100 or 200. Setting size to 200 means there are 1/4 as many page requests, which increases performance for fetching the data by about the same factor